### PR TITLE
fix(bind-attrs): fix transition-group animation

### DIFF
--- a/packages/vuetify/src/mixins/binds-attrs/index.ts
+++ b/packages/vuetify/src/mixins/binds-attrs/index.ts
@@ -17,7 +17,6 @@ function makeWatcher (property: string): ThisType<Vue> & WatchOptionsWithHandler
         this.$set(this.$data[property], attr, val[attr])
       }
     },
-    immediate: true,
   }
 }
 
@@ -32,5 +31,14 @@ export default Vue.extend({
     // Make sure to use `attrs$` instead of `$attrs` (confusing right?)
     $attrs: makeWatcher('attrs$'),
     $listeners: makeWatcher('listeners$'),
+  },
+  
+  created () {
+    for (const attr in $attrs) {
+      this.$set(this.attrs$, attr, $attrs[attr])
+    }
+    for (const attr in $listeners) {
+      this.$set(this.listeners$, attr, $listeners[attr])
+    }
   },
 })


### PR DESCRIPTION
fix #9171

<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/vuetifyjs/vuetify/blob/master/.github/CONTRIBUTING.md

Testing and markup sections can be removed for documentation changes
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!--- Describe your changes in detail -->
The watchers with `immediate: true` is removed as using $set in it causes issue in transition groups. Instead, the initialization is moved to created.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current bind-attrs uses $set inside immediate watchers to set attrs$ and listeners$, this causes issues with transition groups where the enter animation directly "snaps". It seems to be a bug in Vue and I have opened [an issue there](https://github.com/vuejs/vue/issues/10596).
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes #9171.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
The changes are tested in [codesandbox](https://codesandbox.io/s/vue-transition-group-bug-wnvwv) and on my personal project.
<!--- Have you created new tests or updated existing ones? -->
<!--- e.g. unit | visually | e2e | none -->

## Markup:
<!--- Paste markup for testing your change --->
<details>

```vue
<template>
  <div id="app">
    <input v-model="open" id="toggle" type="checkbox">
    <label for="toggle">Toggle transition</label>
    <transition-group name="scale">
      <test v-if="open" key="1"></test>
      <test v-if="open" key="2"></test>
    </transition-group>
  </div>
</template>

<script>
function makeWatcher (property) {
  return {
    handler (val, oldVal) {
      for (const attr in oldVal) {
        if (!Object.prototype.hasOwnProperty.call(val, attr)) {
          this.$delete(this.$data[property], attr)
        }
      }
      for (const attr in val) {
        this.$set(this.$data[property], attr, val[attr])
      }
    },
  }
}

export default {
  name: "App",
  components: {
    Test: {
      template: '<div>attrs$: {{ attrs$ }}</div>',
      data: () => ({
        attrs$: {},
        listeners$: {},
      }),

      watch: {
        // Work around unwanted re-renders: https://github.com/vuejs/vue/issues/10115
        // Make sure to use `attrs$` instead of `$attrs` (confusing right?)
        $attrs: makeWatcher('attrs$'),
        $listeners: makeWatcher('listeners$'),
      },
      
      created () {
        for (const attr in $attrs) {
          this.$set(this.attrs$, attr, $attrs[attr])
        }
        for (const attr in $listeners) {
          this.$set(this.listeners$, attr, $listeners[attr])
        }
      },
    }
  },
  data: () => ({
    open: false
  })
};
</script>


<style>
#app {
  font-family: "Avenir", Helvetica, Arial, sans-serif;
  -webkit-font-smoothing: antialiased;
  -moz-osx-font-smoothing: grayscale;
  color: #2c3e50;
  border: 1px solid black;
  padding: 1rem;
}

.scale-enter,
.scale-leave-to {
  opacity: 0;
  transform: scale(0);
}
.scale-enter-active,
.scale-leave-active {
  transition: all 0.5s ease;
}

.scale-move {
  transition: transform 0.6s;
}
</style>

```
</details>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] The PR title is no longer than 64 characters.
- [ x] The PR is submitted to the correct branch (`master` for bug fixes and documentation updates, `dev` for new features and breaking changes).
- [ x] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples to the kitchen (applies to new features and breaking changes in core library)
